### PR TITLE
Revert "Add the ruleset for meetup again"

### DIFF
--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -40,34 +40,9 @@ resource "cloudflare_dns_record" "www" {
 
 resource "cloudflare_dns_record" "meetup" {
   name    = "meetup.nixos-cn.org"
-  proxied = true # proxied = true enables Cloudflare's rules
+  proxied = false
   ttl     = 1
   type    = "CNAME"
-  # just a placeholder, will be redirected to nix.org.cn instead
   content = "nixos-cn.github.io"
   zone_id = cloudflare_zone.nixos_cn_org.id
-}
-
-resource "cloudflare_ruleset" "meetup" {
-  zone_id = cloudflare_zone.nixos_cn_org.id
-  name    = "redirect meetup to nix.org.cn"
-  kind    = "zone"
-  phase   = "http_request_dynamic_redirect"
-
-  rules = [
-    {
-      ref        = "redirect_old_url"
-      expression = "(http.host eq \"meetup.nixos-cn.org\")"
-      action     = "redirect"
-      action_parameters = {
-        from_value = {
-          status_code = 302
-          target_url = {
-            value = "https://nix.org.cn"
-          }
-          preserve_query_string = false
-        }
-      }
-    }
-  ]
 }


### PR DESCRIPTION
Reverts NixOS-CN/nixos-cn-org-configurations#12

It seems that the issue #11 persists.

```log
POST "https://api.cloudflare.com/client/v4/zones/75b1fd9c9c27d1383681f44b596b171c/rulesets": 403 Forbidden {
  "result": null,
  "success": false,
  "errors": [
    {
      "message": "request is not authorized"
    }
  ],
  "messages": []
}
```